### PR TITLE
Fix handling of headers with lowercase field names

### DIFF
--- a/addons/http_manager/autoload/request/response.gd
+++ b/addons/http_manager/autoload/request/response.gd
@@ -31,7 +31,8 @@ func get_content_type() -> String:
 func get_header(header_name: String) -> String:
 	header_name += ":"
 	for h in headers:
-		if h.begins_with(header_name):
+		# Header field names are case-insensitive. RFC-7230 & RFC-7540
+		if h.to_lower().begins_with(header_name.to_lower()):
 			return h.substr(header_name.length()).strip_edges()
 	return ""
 


### PR DESCRIPTION
According to the RFC for http/1.1 and http/2.0 the header names are case insensitive and certain web servers will send all lowercase field names.